### PR TITLE
property name containing number

### DIFF
--- a/CalcBinding/CalcBinding.cs
+++ b/CalcBinding/CalcBinding.cs
@@ -204,7 +204,8 @@ namespace CalcBinding
 
             foreach (var match in matches)
             {
-                if (!Regex.IsMatch(match, @"\d") && !match.Contains("\""))
+                double result;
+                if (!Double.TryParse(match, out result) && !match.Contains("\""))
                 {
                     // math detection
                     if (!Regex.IsMatch(match, @"Math.\w+\(\w+\)") && !Regex.IsMatch(match, @"Math.\w+"))

--- a/Tests/CalcBindingSystemTests.cs
+++ b/Tests/CalcBindingSystemTests.cs
@@ -36,6 +36,11 @@ namespace Tests
                 () => test.A = 20.34, "20.34", 20.34
             );
 
+            StringAndObjectBindingAssert("N1", test,
+                () => test.N1 = 10, "10", (double)10,
+                () => test.N1 = 20.34, "20.34", 20.34
+            );
+
             StringAndObjectBindingAssert("A+B+C", test,
                 () => { test.A = 10; test.B = 20; test.C = -2; }, "28", (double)28,
                 () => { test.A = 20.34; test.B = 15; test.C = 12; }, "47.34", 47.34

--- a/WpfExample/ExampleViewModel.cs
+++ b/WpfExample/ExampleViewModel.cs
@@ -170,6 +170,20 @@ namespace WpfExample
     /// </summary>
     public class ExampleViewModel : BaseViewModel
     {
+        private double n1 = 10;
+        public double N1
+        {
+            get { return n1; }
+            set
+            {
+                n1 = value;
+
+                new object().TraceTime(
+                    () => RaisePropertyChanged(() => N1)
+                );
+            }
+        }
+
         private double a = 10;
         public double A
         {


### PR DESCRIPTION
My ViewModel has properties that contain numbers in their names. Binding those does not work and I added a test case.

I tracked it down to the '!Regex.IsMatch(match, @"\d")' condition in Binding.GetSourcePropertiesPathes. How can I get it to bind to those properties as well?