### PR TITLE
Fixed ArgumentException when used in Setter.Value

### DIFF
--- a/CalcBinding/CalcBinding.cs
+++ b/CalcBinding/CalcBinding.cs
@@ -16,7 +16,7 @@ namespace CalcBinding
     /// <summary>
     /// Binding with advantages
     /// </summary>
-    public sealed class Binding : MarkupExtension
+    public sealed class Binding : DynamicResourceExtension
     {
         // We cannot use PropertyPath instead of string (such as standart Binding) because transformation from xaml value string to Property path 
         // is doing automatically by PropertyPathConverter and result PropertyPath object could have form, that cannot retranslate to normal string.


### PR DESCRIPTION
same as #46, but I change the text and commit message to English.

When used inside a Setter.Value (as follows), ArgumentException occurs in Visual Studio design mode.
```
<Style TargetType="ComboBox" >
  <Setter Property="IsEnabled" Value="{c:Binding 1>1}" />
</Style>
```
The error message is `'Binding' is not valid for Setter.Value. The only supported MarkupExtension types are DynamicResourceExtension and BindingBase or derived types.`

By inheriting DynamicResourceExtension, the error will disappear.

